### PR TITLE
Fix issue due to non existing self-signed certificate for 127.0.0.1

### DIFF
--- a/autoscript.js
+++ b/autoscript.js
@@ -1261,7 +1261,7 @@ var AutoScript = (function (window) {
     /* Tiempo de retardo para peticiones */
     var WAITING_TIME = 500;
 
-    var URL_REQUEST = "https://127.0.0.1:";
+    var URL_REQUEST = "https://localhost:";
 
     /* Respuesta del socket a la peticion realizada */
     var totalResponseRequest = "";


### PR DESCRIPTION
This change allows urls using ssl to work in computers with self-signed certificates for localhost. Normally, there's no self-signed certificate for 127.0.0.1. I have this many issues in several websites because of that problem.